### PR TITLE
Fix broken link to meetup page

### DIFF
--- a/_posts/2017-11-02-gotomeetup-now-.markdown
+++ b/_posts/2017-11-02-gotomeetup-now-.markdown
@@ -5,7 +5,7 @@ date:   2017-10-25 12:00:00 -0500
 categories: meeting board
 ---
 
-CIJUG.net has served the Central Iowa Java community for several years.  As our group has grown, the needs and purpose of this site have changed.  As such, we have moved our meeting notices and management to Meetup.com.  We invite all of our members to join us there.  Please visit [our new Meetup page](https://www.meetup.com/preview/central-iowa-java-users-group) and join up today!  
+CIJUG.net has served the Central Iowa Java community for several years.  As our group has grown, the needs and purpose of this site have changed.  As such, we have moved our meeting notices and management to Meetup.com.  We invite all of our members to join us there.  Please visit [our new Meetup page](https://www.meetup.com/central-iowa-java-users-group/) and join up today!  
   
 Moving forward, this site will be repurposed in several ways.  First, you will begin to see more information about the Central Iowa Java Users Group, its board members, and the goals we are working towards.  Second, we now have a partnership with DMACC to provide us audio and video resources.  We will soon begin hosting recordings of our meetings here.  Lastly, we hope to begin using this site as a resource for our sponsors.  Expect to see more content from those that have been helping our group grow over the years.
   


### PR DESCRIPTION
The [`/preview`](https://www.meetup.com/preview/central-iowa-java-users-group/) in the existing link was returning a `404` page